### PR TITLE
fix: projector estimate ignores --flash-attention, charging a phantom F32 attention score matrix

### DIFF
--- a/file_estimate__llamacpp.go
+++ b/file_estimate__llamacpp.go
@@ -971,6 +971,9 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 		e.OffloadLayers = 0
 	}
 
+	// Flash attention.
+	e.FlashAttention = o.FlashAttention
+
 	// Footprint.
 	{
 		// Bootstrap.
@@ -1248,6 +1251,12 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 				compVcur := GGMLTypeF32.RowSizeOf([]uint64{nEmbd, nPositions})
 				compKcur := GGMLTypeF32.RowSizeOf([]uint64{nEmbd, nPositions})
 				compKQcur := GGMLTypeF32.RowSizeOf([]uint64{nPositions, nPositions, nHead})
+				if o.FlashAttention {
+					// The attention score matrix is not materialized with flash attention,
+					// the largest quadratic tensor left is the F16-cast mask,
+					// see https://github.com/ggml-org/llama.cpp/blob/e3546c7948e3af463d0b401e6421d5a4c2faf565/tools/mtmd/clip.cpp#L690-L700.
+					compKQcur = GGMLTypeF16.RowSizeOf([]uint64{nPositions, nPositions})
+				}
 				e.Devices[idx].Computation.Compute += GGUFBytesScalar(compNorm + compVcur + compKcur + compKQcur)
 			}
 		}
@@ -1306,6 +1315,11 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 				compVcur := GGMLTypeF32.RowSizeOf([]uint64{nEmbd, nPositions})
 				compKcur := GGMLTypeF32.RowSizeOf([]uint64{nEmbd, nPositions})
 				compKQcur := GGMLTypeF32.RowSizeOf([]uint64{nPositions, nPositions, nHead})
+				if o.FlashAttention {
+					// The audio encoder shares the clip attention graph,
+					// see https://github.com/ggml-org/llama.cpp/blob/e3546c7948e3af463d0b401e6421d5a4c2faf565/tools/mtmd/clip.cpp#L690-L700.
+					compKQcur = GGMLTypeF16.RowSizeOf([]uint64{nPositions, nPositions})
+				}
 				e.Devices[idx].Computation.Compute += GGUFBytesScalar(compNorm + compVcur + compKcur + compKQcur)
 			}
 		}

--- a/file_estimate__llamacpp.go
+++ b/file_estimate__llamacpp.go
@@ -909,23 +909,6 @@ func (gf *GGUFFile) estimateLLaMACppRunInModel(o *_GGUFRunEstimateOptions, a *GG
 	}
 }
 
-// isKnownClipProjector returns true if the clip projector of the given architecture
-// is one of those estimated explicitly by estimateLLaMACppRunInProjector.
-func isKnownClipProjector(a *GGUFArchitecture) bool {
-	if a.ClipHasQwen2VLMerger || a.ClipHasLLaVAProjector || a.ClipHasMiniCPMVProjector {
-		return true
-	}
-	switch a.ClipProjectorType {
-	case "mlp", "mlp_norm", "ldp", "ldpv2",
-		"resampler", "adapter",
-		"qwen2vl_merger", "qwen2.5vl_merger", "qwen2.5o",
-		"gemma3", "idefics3", "llama4",
-		"pixtral", "internvl", "lightonocr":
-		return true
-	}
-	return false
-}
-
 // estimateLLaMACppRunInProjector estimates the usages of the GGUF file for projector.
 func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a *GGUFArchitecture, e *LLaMACppRunEstimate) {
 	ls := gf.Layers()
@@ -1036,24 +1019,15 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 		//     https://github.com/ggerganov/llama.cpp/blob/0827b2c1da299805288abbd556d869318f2b121e/examples/llava/clip.cpp#L2767-L2794.
 		heightMaxSize = uint64(a.ClipVisionImageSize)
 		widthMaxSize = heightMaxSize
-		switch {
-		case a.ClipHasQwen2VLMerger ||
+		if a.ClipHasQwen2VLMerger ||
 			a.ClipProjectorType == "qwen2vl_merger" ||
 			a.ClipProjectorType == "qwen2.5vl_merger" ||
 			a.ClipProjectorType == "qwen2.5o" ||
 			a.ClipProjectorType == "pixtral" ||
-			a.ClipProjectorType == "lightonocr":
+			a.ClipProjectorType == "lightonocr" {
 			// See https://github.com/ggml-org/llama.cpp/blob/ec9e0301fef6476df83e94842c3b625501c95566/tools/mtmd/clip.cpp#L2217.
 			heightMaxSize = uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024))
 			widthMaxSize = heightMaxSize
-		case !isKnownClipProjector(a):
-			// Cap the image size of an unknown projector type instead of trusting the native image size,
-			// which otherwise inflates the estimate,
-			// see https://github.com/gpustack/gguf-parser-go/issues/21.
-			if ms := uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024)); heightMaxSize > ms {
-				heightMaxSize = ms
-				widthMaxSize = ms
-			}
 		}
 		nPatchSize := uint64(a.ClipVisionPatchSize)
 		nPatchesHeight := heightMaxSize / nPatchSize
@@ -1163,11 +1137,17 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 				projectionDim = ti.Dimensions[1]
 			}
 		default:
-			if !isKnownClipProjector(a) {
+			if !a.ClipHasQwen2VLMerger && !a.ClipHasLLaVAProjector && !a.ClipHasMiniCPMVProjector {
 				// Approximate an unknown projector type instead of falling through every special case:
+				// cap the image size instead of trusting the native one,
 				// honor the spatial merge size if present,
 				// and fall back to the declared projection dimension,
 				// see https://github.com/gpustack/gguf-parser-go/issues/21.
+				if ms := uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024)); heightMaxSize > ms {
+					heightMaxSize = ms
+					widthMaxSize = ms
+					nPatches = (heightMaxSize / nPatchSize) * (widthMaxSize / nPatchSize)
+				}
 				if a.ClipVisionSpatialMergeSize > 1 {
 					nPatches /= uint64(a.ClipVisionSpatialMergeSize) * uint64(a.ClipVisionSpatialMergeSize)
 				}

--- a/file_estimate__llamacpp.go
+++ b/file_estimate__llamacpp.go
@@ -1023,8 +1023,7 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			a.ClipProjectorType == "qwen2vl_merger" ||
 			a.ClipProjectorType == "qwen2.5vl_merger" ||
 			a.ClipProjectorType == "qwen2.5o" ||
-			a.ClipProjectorType == "pixtral" ||
-			a.ClipProjectorType == "lightonocr" {
+			a.ClipProjectorType == "pixtral" {
 			// See https://github.com/ggml-org/llama.cpp/blob/ec9e0301fef6476df83e94842c3b625501c95566/tools/mtmd/clip.cpp#L2217.
 			heightMaxSize = uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024))
 			widthMaxSize = heightMaxSize
@@ -1113,7 +1112,7 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			if ti, ok := gf.TensorInfos.Get("mm.model.fc.weight"); ok {
 				projectionDim = ti.Dimensions[1]
 			}
-		case "pixtral", "lightonocr":
+		case "pixtral":
 			heightPatchSize := heightMaxSize / uint64(a.ClipVisionPatchSize)
 			if a.ClipVisionSpatialMergeSize > 0 {
 				heightPatchSize /= uint64(a.ClipVisionSpatialMergeSize)
@@ -1122,14 +1121,9 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			if a.ClipVisionSpatialMergeSize > 0 {
 				widthPatchSize /= uint64(a.ClipVisionSpatialMergeSize)
 			}
-			nPatches = heightPatchSize * widthPatchSize
-			if a.ClipProjectorType == "pixtral" {
-				nPatches += heightPatchSize - 1 /* [IMG_BREAK] per row */
-				if ti, ok := gf.TensorInfos.Get("mm.2.bias"); ok {
-					projectionDim = ti.Dimensions[0]
-				}
-			} else if ti, ok := gf.TensorInfos.Get("mm.2.weight"); ok {
-				projectionDim = ti.Dimensions[1]
+			nPatches = heightPatchSize*widthPatchSize + heightPatchSize - 1 /* [IMG_BREAK] per row */
+			if ti, ok := gf.TensorInfos.Get("mm.2.bias"); ok {
+				projectionDim = ti.Dimensions[0]
 			}
 		case "internvl":
 			nPatches /= uint64(a.ClipVisionProjectorScaleFactor * a.ClipVisionProjectorScaleFactor)
@@ -1138,18 +1132,36 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			}
 		default:
 			if !a.ClipHasQwen2VLMerger && !a.ClipHasLLaVAProjector && !a.ClipHasMiniCPMVProjector {
-				// Approximate an unknown projector type instead of falling through every special case:
-				// cap the image size instead of trusting the native one,
-				// honor the spatial merge size if present,
-				// and fall back to the declared projection dimension,
+				// Approximate a projector type without a special case above from what the GGUF declares,
+				// so that new llama.cpp projector types (lightonocr, paddleocr, dots_ocr, kimivl, ...)
+				// degrade to a rough estimate rather than an inflated one,
 				// see https://github.com/gpustack/gguf-parser-go/issues/21.
-				if ms := uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024)); heightMaxSize > ms {
-					heightMaxSize = ms
-					widthMaxSize = ms
-					nPatches = (heightMaxSize / nPatchSize) * (widthMaxSize / nPatchSize)
+				//
+				// Cap the image size like the known dynamic-resolution projector types,
+				// without inflating a smaller native image size by default.
+				ms := uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024))
+				if o.LMCVisualMaxImageSize == nil && heightMaxSize < ms {
+					ms = heightMaxSize
 				}
+				heightMaxSize = ms
+				widthMaxSize = ms
+				heightPatchSize := (heightMaxSize + nPatchSize - 1) / nPatchSize
+				widthPatchSize := (widthMaxSize + nPatchSize - 1) / nPatchSize
+				// Honor the patch reduction the metadata declares,
+				// like llama.cpp does for every projector type carrying it,
+				// rounding up so the estimate never undercounts.
 				if a.ClipVisionSpatialMergeSize > 1 {
-					nPatches /= uint64(a.ClipVisionSpatialMergeSize) * uint64(a.ClipVisionSpatialMergeSize)
+					sms := uint64(a.ClipVisionSpatialMergeSize)
+					heightPatchSize = (heightPatchSize + sms - 1) / sms
+					widthPatchSize = (widthPatchSize + sms - 1) / sms
+				} else if a.ClipVisionProjectorScaleFactor > 1 {
+					psf := uint64(a.ClipVisionProjectorScaleFactor)
+					heightPatchSize = (heightPatchSize + psf - 1) / psf
+					widthPatchSize = (widthPatchSize + psf - 1) / psf
+				}
+				nPatches = heightPatchSize * widthPatchSize
+				if _, ok := gf.TensorInfos.Get("v.token_embd.img_break"); ok {
+					nPatches += heightPatchSize - 1 /* [IMG_BREAK] per row */
 				}
 				projectionDim = uint64(a.ClipVisionProjectionDim)
 			}

--- a/file_estimate__llamacpp.go
+++ b/file_estimate__llamacpp.go
@@ -1160,7 +1160,7 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 					widthPatchSize = (widthPatchSize + psf - 1) / psf
 				}
 				nPatches = heightPatchSize * widthPatchSize
-				if _, ok := gf.TensorInfos.Get("v.token_embd.img_break"); ok {
+				if _, ok := gf.TensorInfos.Get("v.token_embd.img_break"); ok && heightPatchSize > 0 {
 					nPatches += heightPatchSize - 1 /* [IMG_BREAK] per row */
 				}
 				projectionDim = uint64(a.ClipVisionProjectionDim)

--- a/file_estimate__llamacpp.go
+++ b/file_estimate__llamacpp.go
@@ -909,6 +909,23 @@ func (gf *GGUFFile) estimateLLaMACppRunInModel(o *_GGUFRunEstimateOptions, a *GG
 	}
 }
 
+// isKnownClipProjector returns true if the clip projector of the given architecture
+// is one of those estimated explicitly by estimateLLaMACppRunInProjector.
+func isKnownClipProjector(a *GGUFArchitecture) bool {
+	if a.ClipHasQwen2VLMerger || a.ClipHasLLaVAProjector || a.ClipHasMiniCPMVProjector {
+		return true
+	}
+	switch a.ClipProjectorType {
+	case "mlp", "mlp_norm", "ldp", "ldpv2",
+		"resampler", "adapter",
+		"qwen2vl_merger", "qwen2.5vl_merger", "qwen2.5o",
+		"gemma3", "idefics3", "llama4",
+		"pixtral", "internvl", "lightonocr":
+		return true
+	}
+	return false
+}
+
 // estimateLLaMACppRunInProjector estimates the usages of the GGUF file for projector.
 func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a *GGUFArchitecture, e *LLaMACppRunEstimate) {
 	ls := gf.Layers()
@@ -1019,14 +1036,24 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 		//     https://github.com/ggerganov/llama.cpp/blob/0827b2c1da299805288abbd556d869318f2b121e/examples/llava/clip.cpp#L2767-L2794.
 		heightMaxSize = uint64(a.ClipVisionImageSize)
 		widthMaxSize = heightMaxSize
-		if a.ClipHasQwen2VLMerger ||
+		switch {
+		case a.ClipHasQwen2VLMerger ||
 			a.ClipProjectorType == "qwen2vl_merger" ||
 			a.ClipProjectorType == "qwen2.5vl_merger" ||
 			a.ClipProjectorType == "qwen2.5o" ||
-			a.ClipProjectorType == "pixtral" {
+			a.ClipProjectorType == "pixtral" ||
+			a.ClipProjectorType == "lightonocr":
 			// See https://github.com/ggml-org/llama.cpp/blob/ec9e0301fef6476df83e94842c3b625501c95566/tools/mtmd/clip.cpp#L2217.
 			heightMaxSize = uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024))
 			widthMaxSize = heightMaxSize
+		case !isKnownClipProjector(a):
+			// Cap the image size of an unknown projector type instead of trusting the native image size,
+			// which otherwise inflates the estimate,
+			// see https://github.com/gpustack/gguf-parser-go/issues/21.
+			if ms := uint64(ptr.Deref(o.LMCVisualMaxImageSize, 1024)); heightMaxSize > ms {
+				heightMaxSize = ms
+				widthMaxSize = ms
+			}
 		}
 		nPatchSize := uint64(a.ClipVisionPatchSize)
 		nPatchesHeight := heightMaxSize / nPatchSize
@@ -1112,7 +1139,7 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			if ti, ok := gf.TensorInfos.Get("mm.model.fc.weight"); ok {
 				projectionDim = ti.Dimensions[1]
 			}
-		case "pixtral":
+		case "pixtral", "lightonocr":
 			heightPatchSize := heightMaxSize / uint64(a.ClipVisionPatchSize)
 			if a.ClipVisionSpatialMergeSize > 0 {
 				heightPatchSize /= uint64(a.ClipVisionSpatialMergeSize)
@@ -1121,14 +1148,30 @@ func (gf *GGUFFile) estimateLLaMACppRunInProjector(o *_GGUFRunEstimateOptions, a
 			if a.ClipVisionSpatialMergeSize > 0 {
 				widthPatchSize /= uint64(a.ClipVisionSpatialMergeSize)
 			}
-			nPatches = heightPatchSize*widthPatchSize + heightPatchSize - 1 /* [IMG_BREAK] per row */
-			if ti, ok := gf.TensorInfos.Get("mm.2.bias"); ok {
-				projectionDim = ti.Dimensions[0]
+			nPatches = heightPatchSize * widthPatchSize
+			if a.ClipProjectorType == "pixtral" {
+				nPatches += heightPatchSize - 1 /* [IMG_BREAK] per row */
+				if ti, ok := gf.TensorInfos.Get("mm.2.bias"); ok {
+					projectionDim = ti.Dimensions[0]
+				}
+			} else if ti, ok := gf.TensorInfos.Get("mm.2.weight"); ok {
+				projectionDim = ti.Dimensions[1]
 			}
 		case "internvl":
 			nPatches /= uint64(a.ClipVisionProjectorScaleFactor * a.ClipVisionProjectorScaleFactor)
 			if ti, ok := gf.TensorInfos.Get("mm.model.mlp.3.weight"); ok {
 				projectionDim = ti.Dimensions[1]
+			}
+		default:
+			if !isKnownClipProjector(a) {
+				// Approximate an unknown projector type instead of falling through every special case:
+				// honor the spatial merge size if present,
+				// and fall back to the declared projection dimension,
+				// see https://github.com/gpustack/gguf-parser-go/issues/21.
+				if a.ClipVisionSpatialMergeSize > 1 {
+					nPatches /= uint64(a.ClipVisionSpatialMergeSize) * uint64(a.ClipVisionSpatialMergeSize)
+				}
+				projectionDim = uint64(a.ClipVisionProjectionDim)
 			}
 		}
 

--- a/file_estimate__llamacpp_test.go
+++ b/file_estimate__llamacpp_test.go
@@ -154,6 +154,15 @@ func TestGGUFFile_EstimateLLaMACppRun_Projector(t *testing.T) {
 			smaller.VRAMs[0].NonUMA, dflt.VRAMs[0].NonUMA)
 	}
 
+	// Flash attention must take effect for the projector as well:
+	// the clip encoder does not materialize the attention score matrix with it,
+	// see https://github.com/gpustack/gguf-parser-go/issues/23.
+	fa := f.EstimateLLaMACppRun(WithFlashAttention()).SummarizeItem(false, 0, 0)
+	if fa.VRAMs[0].NonUMA >= dflt.VRAMs[0].NonUMA {
+		t.Errorf("flash attention estimate: NonUMA VRAM %s is not lower than default %s",
+			fa.VRAMs[0].NonUMA, dflt.VRAMs[0].NonUMA)
+	}
+
 	// Unknown or new projector types must be bounded as well,
 	// instead of falling through every special case.
 	for i := range f.Header.MetadataKV {

--- a/file_estimate__llamacpp_test.go
+++ b/file_estimate__llamacpp_test.go
@@ -123,3 +123,46 @@ func TestGGUFFile_EstimateLLaMACppRun_OffloadLayers(t *testing.T) {
 		})
 	}
 }
+
+func TestGGUFFile_EstimateLLaMACppRun_Projector(t *testing.T) {
+	ctx := context.Background()
+
+	f, err := ParseGGUFFileFromHuggingFace(
+		ctx,
+		"noctrex/LightOnOCR-2-1B-GGUF",
+		"mmproj-BF16.gguf",
+		SkipLargeMetadata())
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	const gib = 1 << 30
+
+	// The projector must not be estimated with the native image size and
+	// an un-merged patch count,
+	// see https://github.com/gpustack/gguf-parser-go/issues/21.
+	dflt := f.EstimateLLaMACppRun().SummarizeItem(false, 0, 0)
+	if nonUMA := dflt.VRAMs[0].NonUMA; nonUMA > 2*gib {
+		t.Errorf("default estimate: NonUMA VRAM %s exceeds 2 GiB", nonUMA)
+	}
+
+	// The visual max image size option must take effect for this projector type.
+	smaller := f.EstimateLLaMACppRun(WithLLaMACppVisualMaxImageSize(512)).SummarizeItem(false, 0, 0)
+	if smaller.VRAMs[0].NonUMA >= dflt.VRAMs[0].NonUMA {
+		t.Errorf("visual max image size 512 estimate: NonUMA VRAM %s is not lower than default %s",
+			smaller.VRAMs[0].NonUMA, dflt.VRAMs[0].NonUMA)
+	}
+
+	// Unknown or new projector types must be bounded as well,
+	// instead of falling through every special case.
+	for i := range f.Header.MetadataKV {
+		if f.Header.MetadataKV[i].Key == "clip.projector_type" {
+			f.Header.MetadataKV[i].Value = "future_projector_type"
+		}
+	}
+	unknown := f.EstimateLLaMACppRun().SummarizeItem(false, 0, 0)
+	if nonUMA := unknown.VRAMs[0].NonUMA; nonUMA > 2*gib {
+		t.Errorf("unknown projector type estimate: NonUMA VRAM %s exceeds 2 GiB", nonUMA)
+	}
+}


### PR DESCRIPTION
## Problem

The projector estimate ignores `--flash-attention`: the clip encoder's attention scores are always charged as a full `F32[n_positions, n_positions, n_head]` tensor per layer. llama.cpp's mtmd encoder supports flash attention and never materializes that tensor — the only quadratic term left is the F16 mask.

The text-side estimate already switches its attention accounting on the flag, so the projector side was inconsistent with both llama.cpp and the estimator's own text path. The error grows quadratically with image resolution, reaching tens of GiB at large `--visual-max-image-size`.

## Solution

When the flash-attention option is set, the per-layer attention term is sized as the F16 mask instead of the full per-head score matrix, for both the vision and the audio encoder (they share llama.cpp's clip attention graph). Without the flag, every estimate stays byte-identical.

## Results

NonUMA estimates for the projector, before and after (identical without `--flash-attention` in all cases):

| projector | options | before | after |
|---|---|---|---|
| Qwen2.5-VL-3B | `--flash-attention` | 3.27 GiB | 1.54 GiB |
| Qwen2.5-VL-3B | `--visual-max-image-size 2048 --flash-attention` | **32.12 GiB** | **4.42 GiB** |
| pixtral-12b | `--flash-attention` | 1.93 GiB | 0.93 GiB |
| pixtral-12b | `--visual-max-image-size 2048 --flash-attention` | 17.42 GiB | 1.68 GiB |
| LightOnOCR-2-1B | `--flash-attention` | 0.92 GiB | 0.81 GiB |

With this plus #22, the full repro command from #21 (which passes `--flash-attention`) lands at 3.79 GiB NonUMA, in line with the model's real ~3-4 GiB usage on a CUDA card.

## Testing

The projector estimate test now asserts that enabling flash attention lowers the projector estimate. Verified byte-identical estimates without the flag across qwen2.5vl, pixtral, and lightonocr mmproj files.

Stacked on #22; only the last commit is new to this PR.

Fixes #23
